### PR TITLE
Added app version to redux and code to force a window reload when the version changes

### DIFF
--- a/src/actions/online.ts
+++ b/src/actions/online.ts
@@ -1,13 +1,20 @@
 import { Action, ActionCreator } from 'redux';
 import { ThunkAction } from 'redux-thunk';
 import { getData } from '../api';
+import { setVersion } from './version';
 
-export const checkIfOnline: ActionCreator<
-  ThunkAction<void, void, void, Action>
-> = () => async dispatch => {
+export const checkIfOnline: ActionCreator<ThunkAction<
+  void,
+  void,
+  void,
+  Action
+>> = () => async dispatch => {
   dispatch(checkingIfOnline());
   getData('/api/v1')
-    .then(() => dispatch(setOnline()))
+    .then(response => {
+      dispatch(setOnline());
+      dispatch(setVersion(response.data));
+    })
     .catch(() => dispatch(setOffline()));
 };
 

--- a/src/actions/version.ts
+++ b/src/actions/version.ts
@@ -1,0 +1,8 @@
+export const setVersion = (payload: any) => ({
+  type: 'SET_VERSION',
+  payload: payload,
+});
+
+export const reloadApp = () => ({
+  type: 'RELOAD_APP',
+});

--- a/src/actions/version.ts
+++ b/src/actions/version.ts
@@ -2,7 +2,3 @@ export const setVersion = (payload: any) => ({
   type: 'SET_VERSION',
   payload: payload,
 });
-
-export const reloadApp = () => ({
-  type: 'RELOAD_APP',
-});

--- a/src/reducers/index.ts
+++ b/src/reducers/index.ts
@@ -8,6 +8,7 @@ import simple from './simple';
 import simpleList from './simpleList';
 import updateServiceWorker from './updateServiceWorker';
 import online from './online';
+import version from './version';
 import referral from './referral';
 import { SubscriptionData } from '../types/subscription';
 import { GroupInfoData, Balance } from '../types/groupInfo';
@@ -33,6 +34,7 @@ export default (history: any) =>
     language,
     updateServiceWorker,
     online,
+    version,
     selectedTimeframe,
     selectedAccounts,
     referral,

--- a/src/reducers/version.ts
+++ b/src/reducers/version.ts
@@ -1,0 +1,17 @@
+const initialState = {
+  version: 0,
+};
+
+const version = (state = initialState, action: any) => {
+  if (action.type === 'SET_VERSION') {
+    const newVersion = action.payload.version;
+    if (state.version > 0 && state.version !== newVersion) {
+      // outdated version, force app reload
+      window.location.reload();
+    }
+    return { ...state, version: newVersion };
+  }
+  return state;
+};
+
+export default version;

--- a/src/reducers/version.ts
+++ b/src/reducers/version.ts
@@ -7,7 +7,9 @@ const version = (state = initialState, action: any) => {
     const newVersion = action.payload.version;
     if (state.version > 0 && state.version !== newVersion) {
       // outdated version, force app reload
-      window.location.reload();
+      setTimeout(() => {
+        window.location.reload();
+      }, 1000);
     }
     return { ...state, version: newVersion };
   }


### PR DESCRIPTION
Since we've split the app into a bunch of different chunks to load as-needed, there's the possibility for the app to get out of sync with the actual latest chunks being served after a deploy. We've added automatic version reporting to the API status endpoint, where the version gets autoincremented with each deploy. The app now stores the version as reported by the API and forces a window reload (to get a new index.html with updated chunk ids) when the version changes.