### PR TITLE
fix: links font size on warning messages to be the same as the parent…

### DIFF
--- a/src/components/NotificationMessage.tsx
+++ b/src/components/NotificationMessage.tsx
@@ -39,7 +39,8 @@ export const Container = styled.div<ContainerProps>`
       ${(props) => (props.error ? 'var(--brand-orange)' : 'var(--brand-green)')};
     border-left: 60px solid transparent;
   }
-  p {
+  p,
+  a {
     font-size: 22px;
   }
 `;


### PR DESCRIPTION
… element

Please confirm that you have completed the following:

- [x] Merge the latest code from `integrations` into this branch
